### PR TITLE
uint_tuple_zip_benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ In many respects, this is my crack at the last task in the <br/>
 `Pointer`<br/>
 `Reference` <br/>
 `uint_t` <br/>
+`uint_bit_size` <br/>
 `ValueType`
 
 Collection of basic template magic stuff.
@@ -428,10 +429,10 @@ Repeat the same operation multiple types without the loop.
 
 _implemented by Oleg Fatkhiev(@ofats)_
 
-_TODO: comparison functions_
-_TODO: benchmarks_
-_TODO: codegen is not there yet_
-_TODO: warn or fail on using bigger type_
+_TODO: comparison functions_ <br>
+_TODO: benchmarks_ <br>
+_TODO: warn or fail on using bigger type_ <br>
+_TODO: report to clang slow codegen for pair bug_ <br>
 
 A tuple that stores unsigned numbers into a single unsgined integer of an appropritate size.<br/>
 The main benefit is the abitlity to compare them with one machine instruction.
@@ -440,12 +441,11 @@ Also possibility to pack data sometimes can be very useful.
 Thanks to Philip Trettner for help with paddings and comparisons.
 Some inspiration from [Andrew Alexandrescu's talk, Writing Quick Code in C++, Quickly](https://youtu.be/ea5DiCg8HOY) - about Tudor Bosman's bitfield stuff.
 
-Looked at the codegen for shifts vs manually selecting elements in the struct.<br/>
-Clang generates identical code for the simplest case. I'm impressed.
-https://gcc.godbolt.org/z/C1d0MO
+Looked at the codegen for shifts vs pairs and structs.<br/>
+Clang generates identical code for the simplest case.
+For the set 2 uints vs a pair, clang generates different code (shitfs + 1 store anstead of two stores and this is faster according to my measurements - see zip_to_pair benchmark)
+https://gcc.godbolt.org/z/YfdnZo
 
-For two ints it still does not. Which requires measurements, but ideally it means
- that I can use bit shifts and write portable and efficient code.
 
 ## Bench (generic/runnable)
 
@@ -529,6 +529,19 @@ Merge with small - benchmarks merge of a big first range with a small second one
 `sort_int_vec`
 
 Benchmarking sort like algorithms.
+
+### zip_to_pair
+
+`use_pair`<br/>
+`use_uint_tuple_first_second`<br/>
+`use_uint_tuple_second_first`<br/>
+`zip_to_pair_common`<br/>
+`zip_to_pair_bit_size`
+
+Benchmarking popluating a number of elemts into a vector of pairs using different types of pairs.<br/>
+Pairs are of the same uint type for both elements.<br/>
+This was to measure wether a different codegen for uint_tuple vs std::pair is better or worse.<br/>
+On my machine - noticebaly better.
 
 ## Test
 

--- a/data/plots/algorithm_settings.json
+++ b/data/plots/algorithm_settings.json
@@ -60,5 +60,16 @@
     "algo_stable_sort_lifting": {
       "display_name" : "algo::stable_sort_lifting"
     }
+  },
+  "uint_tuple": {
+    "use_uint_tuple_first_second" : {
+      "display_name" : "uint_tuple (write first then second)"
+    },
+    "use_uint_tuple_second_first" : {
+      "display_name" : "uint_tuple (write second then first)"
+    },
+    "use_pair" : {
+      "display_name" : "std::pair"
+    }
   }
 }

--- a/data/plots/zip_to_pair_bit_size_base.json
+++ b/data/plots/zip_to_pair_bit_size_base.json
@@ -1,0 +1,6 @@
+{
+  "general": {
+    "algorithm_settings_section" : "uint_tuple",
+    "algorithm_settings_url" : "data/plots/algorithm_settings.json"
+  }
+}

--- a/data/zip_to_pair_bit_size_ignore_1000/description.json
+++ b/data/zip_to_pair_bit_size_ignore_1000/description.json
@@ -1,0 +1,20 @@
+{
+  "base": "data/plots/zip_to_pair_bit_size_base.json",
+  "general": {
+    "title": "zip to pair bit size ignore 1000"
+  },
+  "measurements": [
+    {
+      "name": "use_pair",
+      "url": "data/zip_to_pair_bit_size_ignore_1000/use_pair.json"
+    },
+    {
+      "name": "use_uint_tuple_second_first",
+      "url": "data/zip_to_pair_bit_size_ignore_1000/use_uint_tuple_second_first.json"
+    },
+    {
+      "name": "use_uint_tuple_first_second",
+      "url": "data/zip_to_pair_bit_size_ignore_1000/use_uint_tuple_first_second.json"
+    }
+  ]
+}

--- a/data/zip_to_pair_bit_size_ignore_1000/use_pair.json
+++ b/data/zip_to_pair_bit_size_ignore_1000/use_pair.json
@@ -1,0 +1,66 @@
+{
+  "context": {
+    "date": "2019-10-31 01:34:59",
+    "executable": "build/src/bench_runnable/zip_to_pair_bit_size_ignore_1000/use_pair",
+    "num_cpus": 4,
+    "mhz_per_cpu": 1800,
+    "cpu_scaling_enabled": false,
+    "caches": [
+      {
+        "type": "Data",
+        "level": 1,
+        "size": 32768000,
+        "num_sharing": 2
+      },
+      {
+        "type": "Instruction",
+        "level": 1,
+        "size": 32768000,
+        "num_sharing": 2
+      },
+      {
+        "type": "Unified",
+        "level": 2,
+        "size": 262144000,
+        "num_sharing": 2
+      },
+      {
+        "type": "Unified",
+        "level": 3,
+        "size": 3145728000,
+        "num_sharing": 4
+      }
+    ],
+    "library_build_type": "release"
+  },
+  "benchmarks": [
+    {
+      "name": "zip_to_pair_bit_size<SELECTED_ALGORITHM>/1000/8",
+      "iterations": 8268563,
+      "real_time": 8.3240256742331084e+01,
+      "cpu_time": 8.3088439913924589e+01,
+      "time_unit": "ns"
+    },
+    {
+      "name": "zip_to_pair_bit_size<SELECTED_ALGORITHM>/1000/16",
+      "iterations": 4216486,
+      "real_time": 1.6561118073131919e+02,
+      "cpu_time": 1.6531775511646427e+02,
+      "time_unit": "ns"
+    },
+    {
+      "name": "zip_to_pair_bit_size<SELECTED_ALGORITHM>/1000/32",
+      "iterations": 2089746,
+      "real_time": 3.3498568773008429e+02,
+      "cpu_time": 3.3438465727413762e+02,
+      "time_unit": "ns"
+    },
+    {
+      "name": "zip_to_pair_bit_size<SELECTED_ALGORITHM>/1000/64",
+      "iterations": 1956362,
+      "real_time": 3.5763566864974797e+02,
+      "cpu_time": 3.5701930419830262e+02,
+      "time_unit": "ns"
+    }
+  ]
+}

--- a/data/zip_to_pair_bit_size_ignore_1000/use_uint_tuple_first_second.json
+++ b/data/zip_to_pair_bit_size_ignore_1000/use_uint_tuple_first_second.json
@@ -1,0 +1,66 @@
+{
+  "context": {
+    "date": "2019-10-31 01:35:07",
+    "executable": "build/src/bench_runnable/zip_to_pair_bit_size_ignore_1000/use_uint_tuple_first_second",
+    "num_cpus": 4,
+    "mhz_per_cpu": 1800,
+    "cpu_scaling_enabled": false,
+    "caches": [
+      {
+        "type": "Data",
+        "level": 1,
+        "size": 32768000,
+        "num_sharing": 2
+      },
+      {
+        "type": "Instruction",
+        "level": 1,
+        "size": 32768000,
+        "num_sharing": 2
+      },
+      {
+        "type": "Unified",
+        "level": 2,
+        "size": 262144000,
+        "num_sharing": 2
+      },
+      {
+        "type": "Unified",
+        "level": 3,
+        "size": 3145728000,
+        "num_sharing": 4
+      }
+    ],
+    "library_build_type": "release"
+  },
+  "benchmarks": [
+    {
+      "name": "zip_to_pair_bit_size<SELECTED_ALGORITHM>/1000/8",
+      "iterations": 9045681,
+      "real_time": 7.7780521665994897e+01,
+      "cpu_time": 7.7634619217723895e+01,
+      "time_unit": "ns"
+    },
+    {
+      "name": "zip_to_pair_bit_size<SELECTED_ALGORITHM>/1000/16",
+      "iterations": 7093348,
+      "real_time": 9.7865177911329496e+01,
+      "cpu_time": 9.7647542458088921e+01,
+      "time_unit": "ns"
+    },
+    {
+      "name": "zip_to_pair_bit_size<SELECTED_ALGORITHM>/1000/32",
+      "iterations": 3708884,
+      "real_time": 1.8706089459937181e+02,
+      "cpu_time": 1.8679365544999521e+02,
+      "time_unit": "ns"
+    },
+    {
+      "name": "zip_to_pair_bit_size<SELECTED_ALGORITHM>/1000/64",
+      "iterations": 1946164,
+      "real_time": 3.6011793970405427e+02,
+      "cpu_time": 3.5946765020830725e+02,
+      "time_unit": "ns"
+    }
+  ]
+}

--- a/data/zip_to_pair_bit_size_ignore_1000/use_uint_tuple_second_first.json
+++ b/data/zip_to_pair_bit_size_ignore_1000/use_uint_tuple_second_first.json
@@ -1,0 +1,66 @@
+{
+  "context": {
+    "date": "2019-10-31 01:35:03",
+    "executable": "build/src/bench_runnable/zip_to_pair_bit_size_ignore_1000/use_uint_tuple_second_first",
+    "num_cpus": 4,
+    "mhz_per_cpu": 1800,
+    "cpu_scaling_enabled": false,
+    "caches": [
+      {
+        "type": "Data",
+        "level": 1,
+        "size": 32768000,
+        "num_sharing": 2
+      },
+      {
+        "type": "Instruction",
+        "level": 1,
+        "size": 32768000,
+        "num_sharing": 2
+      },
+      {
+        "type": "Unified",
+        "level": 2,
+        "size": 262144000,
+        "num_sharing": 2
+      },
+      {
+        "type": "Unified",
+        "level": 3,
+        "size": 3145728000,
+        "num_sharing": 4
+      }
+    ],
+    "library_build_type": "release"
+  },
+  "benchmarks": [
+    {
+      "name": "zip_to_pair_bit_size<SELECTED_ALGORITHM>/1000/8",
+      "iterations": 9065713,
+      "real_time": 7.5539258522498656e+01,
+      "cpu_time": 7.5414586806354890e+01,
+      "time_unit": "ns"
+    },
+    {
+      "name": "zip_to_pair_bit_size<SELECTED_ALGORITHM>/1000/16",
+      "iterations": 7084088,
+      "real_time": 9.7829853891738438e+01,
+      "cpu_time": 9.7671993910860536e+01,
+      "time_unit": "ns"
+    },
+    {
+      "name": "zip_to_pair_bit_size<SELECTED_ALGORITHM>/1000/32",
+      "iterations": 3725525,
+      "real_time": 1.8729062561569359e+02,
+      "cpu_time": 1.8697874796169666e+02,
+      "time_unit": "ns"
+    },
+    {
+      "name": "zip_to_pair_bit_size<SELECTED_ALGORITHM>/1000/64",
+      "iterations": 1947566,
+      "real_time": 3.5978899354275239e+02,
+      "cpu_time": 3.5910310613350208e+02,
+      "time_unit": "ns"
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -16,6 +16,8 @@
   <a href="#lower_bounds">lower bounds</a>
   <a href="#merges">merges</a>
   <a href="#sorts">sorts</a>
+  <a href="#uint_tuple">uint_tuple</a>
+
 
   <a name="apply_rearrangments"></a>
   <h2><a href="#apply_rearrangments">Apply rearrangments</a></h2>
@@ -100,4 +102,18 @@
       'data/sort_size_{}_100/description.json',
       ['int', 'double', 'std_int64_t', 'fake_url', 'fake_url_pair', 'noinline_int']);
   </script>
+
+  <a name="uint_tuple"></a>
+  <h2><a href="#uint_tuple">Uint tuple</a></h2>
+
+  <h3>Zip to pair</h3>
+  Zip to pair doesn't super well fit into my current visualization framework.<br/>
+  It measures how much faster it is to populate a uint_tuple&lt;x,x&gt; compared to std::pair.<br/>
+  I believe this to be a clang codegen bug.<br/><br/>
+
+  <div id='uint_tuple_1000'></div>
+  <script>visualizeBecnhmarksForTypes('uint_tuple_1000',
+      'data/zip_to_pair_bit_size_{}_1000/description.json', ['ignore']);
+  </script>
+
 </body>

--- a/scripts/all_uint_tuple_benchmarks.sh
+++ b/scripts/all_uint_tuple_benchmarks.sh
@@ -1,0 +1,1 @@
+python3 scripts/run_benchmark_folder.py data/plots/zip_to_pair_bit_size_base.json build/src/bench_runnable/zip_to_pair_bit_size_ignore_1000 data

--- a/src/algo/type_functions.h
+++ b/src/algo/type_functions.h
@@ -18,6 +18,7 @@
 #define ALGO_TYPE_FUNCTIONS_H
 
 #include <array>
+#include <climits>
 #include <iterator>
 #include <type_traits>
 
@@ -32,7 +33,7 @@ struct type_t {
 
 struct null_t {};
 
-namespace detail {
+namespace _type_functions {
 
 template <typename I>
 struct is_move_iterator : std::false_type {};
@@ -84,7 +85,7 @@ constexpr auto uint_t_impl() {
   }
 }
 
-}  // namespace detail
+}  // namespace _type_functions
 
 template <typename I>
 using ValueType = typename std::iterator_traits<I>::value_type;
@@ -114,17 +115,17 @@ constexpr bool RandomAccessIterator =
     std::is_base_of_v<std::random_access_iterator_tag, IteratorCategory<I>>;
 
 template <typename I>
-constexpr bool MoveIterator = detail::is_move_iterator<I>::value;
+constexpr bool MoveIterator = _type_functions::is_move_iterator<I>::value;
 
 template <typename I>
-constexpr bool ReverseIterator = detail::is_reverse_iterator<I>::value;
+constexpr bool ReverseIterator = _type_functions::is_reverse_iterator<I>::value;
 
 template <typename F>
 // require UnaryCallable<F>
-using ArgumentType = typename detail::argument_type_impl<F>::type;
+using ArgumentType = typename _type_functions::argument_type_impl<F>::type;
 
 template <size_t N>
-using uint_t = typename decltype(detail::uint_t_impl<N>())::type;
+using uint_t = typename decltype(_type_functions::uint_t_impl<N>())::type;
 
 inline constexpr std::array supported_uint_sizes = {
     size_t{8},   //
@@ -136,6 +137,16 @@ inline constexpr std::array supported_uint_sizes = {
     size_t{128}  //
 #endif           // HAS_128_INTS
 };
+
+template <typename T>
+constexpr auto uint_bit_size() -> std::enable_if_t<std::is_unsigned_v<T>, size_t> {
+  auto* f = supported_uint_sizes.begin();
+  while (f != supported_uint_sizes.end()) {
+    if (*f == sizeof(T) * CHAR_BIT) return *f;
+    ++f;
+  }
+  throw null_t{};  // compile time assert
+}
 
 }  // namespace algo
 

--- a/src/bench_generic/set_parameters.h
+++ b/src/bench_generic/set_parameters.h
@@ -54,6 +54,14 @@ inline void set_5_size_increases(benchmark::internal::Benchmark* b) {
   }
 }
 
+template <size_t total_size>
+inline void set_every_int_size(benchmark::internal::Benchmark* b) {
+  b->Args({static_cast<int>(total_size), 8});
+  b->Args({static_cast<int>(total_size), 16});
+  b->Args({static_cast<int>(total_size), 32});
+  b->Args({static_cast<int>(total_size), 64});
+}
+
 }  // namespace bench
 
 #endif  // BENCH_SET_PARAMETERS_H

--- a/src/bench_generic/zip_to_pair.h
+++ b/src/bench_generic/zip_to_pair.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 Denis Yaroshevskiy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef BENCH_GENERIC_ZIP_TO_PAIR_H
+#define BENCH_GENERIC_ZIP_TO_PAIR_H
+
+#include <utility>
+
+#include <benchmark/benchmark.h>
+
+#include "algo/type_functions.h"
+#include "algo/uint_tuple.h"
+
+#include "bench_generic/declaration.h"
+#include "bench_generic/input_generators.h"
+
+namespace bench {
+
+struct use_pair {
+  template <size_t size>
+  using type = std::pair<algo::uint_t<size>, algo::uint_t<size>>;
+
+  template <typename T, typename U>
+  constexpr auto operator()(T x, U y) const {
+    return std::pair{x, y};
+  }
+};
+
+struct use_uint_tuple_first_second {
+  template <size_t size>
+  using type = algo::uint_tuple<size, size>;
+
+  template <typename T, typename U>
+  constexpr auto operator()(T x, U y) const {
+    algo::uint_tuple<algo::uint_bit_size<T>(), algo::uint_bit_size<U>()> res;
+    algo::set_at<0>(res, x);
+    algo::set_at<1>(res, y);
+    return res;
+  }
+};
+
+struct use_uint_tuple_second_first {
+  template <size_t size>
+  using type = algo::uint_tuple<size, size>;
+
+  template <typename T, typename U>
+  constexpr auto operator()(T x, U y) const {
+    algo::uint_tuple<algo::uint_bit_size<T>(), algo::uint_bit_size<U>()> res;
+    algo::set_at<1>(res, y);
+    algo::set_at<0>(res, x);
+    return res;
+  }
+};
+
+template <typename Converter, typename N, typename T>
+BENCH_DECL_ATTRIBUTES void zip_to_pair_common(benchmark::State& state,
+                                              const std::vector<N>& xs,
+                                              const std::vector<N>& ys,
+                                              T* out) {
+  for (auto _ : state) {
+    std::transform(xs.begin(), xs.end(), ys.begin(), out, Converter{});
+    benchmark::DoNotOptimize(out);
+  }
+}
+
+template <size_t size, typename T>
+void zip_to_pair_one_size(benchmark::State& state) {
+  const size_t range_size = state.range(0);
+  auto [xs, ys] =
+      bench::two_random_vectors<algo::uint_t<size>>(range_size, range_size);
+  std::vector<typename T::template type<size>> out{range_size};
+  zip_to_pair_common<T>(state, xs, ys, out.data());
+}
+
+template <typename T>
+void zip_to_pair_bit_size(benchmark::State& state) {
+  const size_t bit_size = static_cast<size_t>(state.range(1));
+  switch (bit_size) {
+    case 8:
+      zip_to_pair_one_size<8, T>(state);
+      break;
+    case 16:
+      zip_to_pair_one_size<16, T>(state);
+      break;
+    case 32:
+      zip_to_pair_one_size<32, T>(state);
+      break;
+    case 64:
+      zip_to_pair_one_size<64, T>(state);
+      break;
+  }
+}
+
+}  // namespace bench
+
+#endif  // BENCH_GENERIC_ZIP_TO_PAIR_H

--- a/src/bench_runnable/CMakeLists.txt
+++ b/src/bench_runnable/CMakeLists.txt
@@ -145,3 +145,9 @@ add_apply_rearrangement_benchmarks(apply_rearrangment fake_url 1000)
 add_apply_rearrangement_benchmarks(apply_rearrangment fake_url_pair 1000)
 
 add_counting_benchmark(apply_rearrangment_1000_counting)
+
+# Uint tuple ##########################
+
+add_benchmark(zip_to_pair_bit_size use_pair ignore  1000)
+add_benchmark(zip_to_pair_bit_size use_uint_tuple_first_second ignore 1000)
+add_benchmark(zip_to_pair_bit_size use_uint_tuple_second_first ignore 1000)

--- a/src/bench_runnable/zip_to_pair_bit_size.cc
+++ b/src/bench_runnable/zip_to_pair_bit_size.cc
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 Denis Yaroshevskiy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "bench_generic/zip_to_pair.h"
+
+#include "bench_generic/set_parameters.h"
+
+namespace bench {
+
+BENCHMARK_TEMPLATE(zip_to_pair_bit_size, SELECTED_ALGORITHM)
+    ->Apply(set_every_int_size<SELECTED_NUMBER>);
+
+}  // namespace bench

--- a/src/test/algo/type_functions.t.cc
+++ b/src/test/algo/type_functions.t.cc
@@ -82,5 +82,15 @@ TEST_CASE("algorithm.uint_t", "[algorithm]") {
   (void)assert_no_such_uint_t<10>{};
 }
 
+TEST_CASE("algorithm.uint_bit_size", "[algorithm]") {
+  static_assert(uint_bit_size<std::uint8_t>() == 8);
+  static_assert(uint_bit_size<std::uint16_t>() == 16);
+  static_assert(uint_bit_size<std::uint32_t>() == 32);
+  static_assert(uint_bit_size<std::uint64_t>() == 64);
+#ifdef HAS_128_INTS
+  static_assert(uint_bit_size<uint_t<128>>() == 128);
+#endif
+}
+
 }  // namespace
 }  // namespace algo

--- a/src/test/bench_generic/input_generators.t.cpp
+++ b/src/test/bench_generic/input_generators.t.cpp
@@ -32,6 +32,15 @@ TEST_CASE("bench.input_generators.generate_random_vector", "[bench]") {
   REQUIRE(res == std::vector(inputs.begin(), inputs.end()));
 }
 
+template <size_t size>
+void uint_t_generate_sorted_vector_test() {
+  std::array inputs = {0, 2, 4};
+  auto src = [&, pos = 0]() mutable { return inputs[pos++]; };
+
+  auto res = generate_sorted_vector<algo::uint_t<size>>(inputs.size(), src);
+  REQUIRE(res == std::vector<algo::uint_t<size>>{0, 2, 4});
+}
+
 TEST_CASE("bench.input_generators.generate_sorted_vector", "[bench]") {
   {
     std::array inputs = {0, 5, 2, 2, 1};
@@ -67,6 +76,11 @@ TEST_CASE("bench.input_generators.generate_sorted_vector", "[bench]") {
     REQUIRE(res[1].data == 2);
     REQUIRE(res[2].data == 4);
   }
+
+  uint_t_generate_sorted_vector_test<8>();
+  uint_t_generate_sorted_vector_test<16>();
+  uint_t_generate_sorted_vector_test<32>();
+  uint_t_generate_sorted_vector_test<64>();
 }
 
 TEST_CASE("bench.input_generators.generate_unique_sorted_vector", "[bench]") {
@@ -114,7 +128,8 @@ TEST_CASE("bench.input_generators.nth_vector_permutation", "[bench]") {
 
 TEST_CASE("bench.input_generators.shuffled_vector", "[bench]") {
   auto run = [](int percentage) {
-    return shuffled_vector(100u, percentage, [](size_t size){ return sorted_vector<int>(size); });
+    return shuffled_vector(
+        100u, percentage, [](size_t size) { return sorted_vector<int>(size); });
   };
 
   {


### PR DESCRIPTION
Benchmark: populate 1000 pairs of integers for different bit sizes of integers.
Comparing `std::pair` and `algo::uint_tuple` - this was the only codegen that was found to be different - populating 2 integers into a `uint_tuple` is done with shifts, while `std::pair` is done with two moves.

Massive win on my machine, and I don't think it's code alignment since I tried different integer sizes.

Hacked around visualized benchmarks, since I really didn't want to write a ton of js at the moment.
Couldn't figure out how to easily make plotly show precise X, so left that as is for now.

Resulting benchmark screenshot:
![Screenshot 2019-10-31 at 01 36 32](https://user-images.githubusercontent.com/11256077/67911604-10a24880-fb7f-11e9-9788-27a5f641f868.png)

On quick-bench:
http://quick-bench.com/aDq3iN3dpi9VWQc8XSd6o7Hlzl4

Will report this one to clang once this get's merged